### PR TITLE
Fix typo: <Pulg> -> <Plug>

### DIFF
--- a/plugin/redl/repl.vim
+++ b/plugin/redl/repl.vim
@@ -84,7 +84,7 @@ function! redl#repl#create(namespace)
   if !hasmapto("<Plug>clj_repl_enter.", "i")
     imap <buffer> <silent> <CR> <Plug>clj_repl_enter.
   endif
-  if !hasmapto("<Pulg>clj_repl_eval.", "i")
+  if !hasmapto("<Plug>clj_repl_eval.", "i")
     imap <buffer> <silent> <C-e> <Plug>clj_repl_eval.
   endif
   if !hasmapto("<Plug>clj_repl_hat.", "n")


### PR DESCRIPTION
Just noticed this while scanning the code.

BTW, so as to not clutter the issues / mailing list, you are creating
buffer-local mappings guarded by `if hasmapto` clauses:

``` vim
  if !hasmapto("<Plug>clj_repl_eval.", "i")
    imap <buffer> <silent> <C-e> <Plug>clj_repl_eval.
  endif
```

However, if there is no event associated with redl#repl#create(), how
can users provide their own mappings to <Plug>clj_repl_\* without mapping
them globally in the clojure FileType?

Great work!

```
guns
```
