### PR TITLE
Use in-ns when creating the repl

### DIFF
--- a/plugin/redl/repl.vim
+++ b/plugin/redl/repl.vim
@@ -75,7 +75,7 @@ function! redl#repl#create(namespace)
   setlocal noswapfile
   set filetype=clojure
   let ns = "'".a:namespace
-  let b:repl_id = fireplace#evalparse('(do (ns '.a:namespace.') (redl.core/make-repl '.ns.'))')
+  let b:repl_id = fireplace#evalparse('(do (in-ns '.ns.') (redl.core/make-repl '.ns.'))')
   let b:repl_namespace = a:namespace
   let b:repl_depth = 0
   let b:repl_history_depth = 0


### PR DESCRIPTION
This avoids blowing away any :exclude lists in :refer-clojure or :use
statements resulting in clojure.lang.Namespace.warnOrFailOnReplace
errors.

e.g.

```
    ;; foo.clj
    (ns foo
      (:refer-clojure :exclude [defn]))

    (defmacro defn [& args] nil)

    ;; bar.clj
    (ns bar
      (:require [foo :refer [defn]])
      (:refer-clojure :exclude [defn]))

    (defn example [])
```

Running :Repl from bar.clj results in:

IllegalStateException defn already refers to: #'foo/defn in namespace: bar
clojure.lang.Namespace.warnOrFailOnReplace (Namespace.java:88)
